### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "angular": "1.4.*",
-    "jquery": "2.1.*"
+    "jquery": ">2.1.*"
   },
   "bugs": {
     "url": "https://github.com/FutureStateMobile/sticky-header/issues"


### PR DESCRIPTION
Currently, jQuery version 2.1 is required. This leads to webpack packaging two jquery versions. As far as I can tell jQuery 3 works fine with sticky heaer